### PR TITLE
Update response for pixee fix --explain

### DIFF
--- a/src/pixee/cli.py
+++ b/src/pixee/cli.py
@@ -390,7 +390,7 @@ def fix(
             console.print(Markdown(f"```diff\n{entry['diff']}```"))
     elif results:
         console.print(
-            "To View the changes, run `pixee explain` or 'pixee fix --explain' for more options"
+            "To View the changes, run 'pixee explain' or 'pixee fix --explain' for more options"
         )
 
 


### PR DESCRIPTION
Introduced explain mode with the command `pixee fix --explain`, to view current changes.
- Add pixee explain in the results of pixee fix . to see the changes.
`To experience the full benefits of automated code hardening via pull requests, install the Pixeebot GitHub app at https://app.pixee.ai`
`To View the changes, run 'pixee explain' or 'pixee fix --explain' for more options`
- Running pixee fix --explain will put the user into explain mode after the results summary.
`To experience the full benefits of automated code hardening via pull requests, install the Pixeebot GitHub app at https://app.pixee.ai`
`Which codemod result would you like to explain? pixee:python/django-session-cookie-secure-off
Secure Setting for Django `SESSION_COOKIE_SECURE` flag (pixee:python/django-session-cookie-secure-off)
This codemod will set django's SESSION_COOKIE_SECURE flag to True if it's False or missing on the settings.py file within django's default     `  
directory structure.

