### PR TITLE
Bug: `explain` fix for no change

### DIFF
--- a/src/pixee/cli.py
+++ b/src/pixee/cli.py
@@ -346,12 +346,7 @@ def fix(
                 console.print(Markdown(f"```diff\n{entry['diff']}```"))
             prompt("Press Enter to continue...")
 
-    result_file = Path(output or DEFAULT_CODETF_PATH)
-
-    Path(result_file).write_text(json.dumps(combined_codetf, indent=2))
-    console.print(f"Results written to {result_file}", style="bold")
-
-    summarize_results(combined_codetf)
+    summarize_results(combined_codetf, output, saved_to_file=True)
 
 
 @main.command()
@@ -384,6 +379,10 @@ def explain(path):
 
     console.print(f"Reading results from `{result_file}`", style="bold")
     summarize_results(combined_codetf)
+
+    if not results:
+        return 0
+
     if (
         codemod := select(
             "Which codemod result would you like to explain?",
@@ -415,13 +414,18 @@ def explain(path):
     return 0
 
 
-def summarize_results(combined_codetf):
+def summarize_results(combined_codetf, output=None, saved_to_file=False):
     results = [
         result for result in combined_codetf["results"] if len(result["changeset"])
     ]
     if not len(results):
         console.print("No changes applied", style="bold")
         return
+
+    if saved_to_file and results:
+        result_file = Path(output or DEFAULT_CODETF_PATH)
+        Path(result_file).write_text(json.dumps(combined_codetf, indent=2))
+        console.print(f"Results written to {result_file}", style="bold")
 
     console.print(
         f"Found {len(results)} opportunities to harden and improve your code:",


### PR DESCRIPTION
- `pixee explain` will work in the case of an empty CodeTF file.
- `pixee fix` will not change the CodeTF file, if their are no changes. 

Fixes(#12)

Suggestion :
I modified the update code to utilize the summarize_results function with the parameters combined_codetf, output=None, and saved_to_file=False. This adjustment eliminates the need for a double loop check for changes recommended by codemodder, making the process more efficient, especially as the number of changes increases. If this approach is not suitable, please inform me, and I will promptly make the necessary adjustments in the same function.