### PR TITLE
📝 Add Pixee Preferences Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ individual skills directly with `npx skills add pixee/pixee-cli --skill <name>`:
 - [`pixee-auth`](./skills/pixee-auth/SKILL.md) — login, status, credential precedence, and
   fixing exit-code-2 failures.
 - [`pixee-api`](./skills/pixee-api/SKILL.md) — the `pixee api` escape hatch and HAL discovery.
+- [`pixee-preferences`](./skills/pixee-preferences/SKILL.md) — read and write Pixee organization
+  preferences from files or stdin.
 - [`pixee-repo`](./skills/pixee-repo/SKILL.md) — `pixee repo list` and the shared `--repo`
   resolution protocol.
 - [`pixee-scan`](./skills/pixee-scan/SKILL.md) — `pixee scan list` and `pixee scan get`, with

--- a/skills/pixee-preferences/SKILL.md
+++ b/skills/pixee-preferences/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: pixee-preferences
+description: "Read and write Pixee organization preferences from files or stdin with optimistic concurrency handled by the CLI."
+metadata:
+  version: 1.0.0
+  openclaw:
+    category: "developer-tools"
+    requires:
+      bins:
+        - pixee
+    cliHelp: "pixee organization preferences --help"
+---
+
+# pixee organization preferences
+
+> **PREREQUISITES:** Read `../pixee-shared/SKILL.md` for global flags, exit codes, and error
+> handling, and `../pixee-auth/SKILL.md` if authentication needs to be configured.
+
+Organization preferences are a freeform markdown blob (≤10,000 characters) that the Pixee
+platform applies to every analysis run for the organization. The content shapes both *triage*
+(is a given finding a real risk for this org?) and *remediation* (how should the fix look in
+this codebase?), and is stored as a single document with audit metadata: `content`,
+`updated_at`, `updated_by`, `org_id`. The MVP hardcodes `org_id` to `default-organization`;
+an `--org-id` flag is planned once the platform supports multi-org.
+
+## pixee organization preferences get
+
+```
+pixee organization preferences get [--content-only]
+```
+
+- Default text output: a two-line `Org: <id>` / `Updated: <iso> by <actor>` header (colon
+  separated, no tabs, because the markdown body is multiline and tabs are reserved for list
+  commands), a blank line, then the `content` body emitted verbatim with no synthetic
+  trailing newline.
+- `--content-only` prints the body alone, byte-for-byte. Designed for piping into a file,
+  `less`, `bat`, or a diff tool. No header, no trailing newline added.
+- `--output json` (or `--json`) emits the full record including the HAL `_links` envelope.
+  See `../pixee-api/SKILL.md` for HAL conventions; do not restate them in scripts.
+- When no preferences have ever been set, the command exits 0 with no stdout and writes a
+  single line to stderr: `no organization preferences set`. Branch on this for
+  fresh-organization flows.
+
+## pixee organization preferences set
+
+```
+pixee organization preferences set (--from-file <path> | --content <string>)
+```
+
+- Exactly one of `--from-file` or `--content` is required; passing both, or neither, is a
+  parse error (exit 1) before any network call.
+- `--from-file -` reads `content` from stdin, enabling get-transform-set pipelines.
+- Content over 10,000 characters is rejected client-side before the round-trip with the
+  observed character count in the error.
+- Optimistic concurrency is handled internally: the CLI performs a GET, then PUTs with
+  `If-Match: <etag>` (or `If-None-Match: *` on first creation). Agents and scripts never
+  touch ETag headers directly.
+- On HTTP 412, the CLI exits 1 with a friendly stderr line:
+  `concurrent modification: another writer updated organization preferences between read and
+  write; re-run to refresh`. Re-running typically succeeds; if multiple writers race
+  repeatedly, refresh and re-author against the latest content.
+- On success, output mirrors `get` (default header + body in text mode, full record in JSON
+  mode).
+
+## Precedence and scope
+
+Pixee resolves preferences per-analysis with strict fallback, no merging:
+
+1. If the repository has `PIXEE.md` at its root (even if empty), it is used exclusively.
+2. Else if organization preferences exist with non-empty `content`, they are used.
+3. Else the analysis runs without preference guidance.
+
+An empty `PIXEE.md` is a deliberate opt-out: a repo with one is treated as having
+preferences, which silently shadows org preferences for that repo. Agents working in a
+specific repo should check for `PIXEE.md` before assuming org preferences will apply.
+
+Humans can author preferences in the Pixee web app under an organization's
+*Settings → Preferences*; the CLI and the web UI write the same resource.
+
+## Writing effective preferences
+
+Preferences come in three flavors:
+
+- **Remediation guidance.** How the team prefers to fix specific vulnerability classes:
+  preferred libraries, internal utility classes, code patterns to use or avoid.
+- **Triage context.** Why a finding may not be a real risk here: deployment architecture,
+  compensating controls (WAF, network isolation, MFA), intentional patterns, false-positive
+  zones.
+- **Rule preferences.** Enable or disable specific scanner rules by tool name and rule ID,
+  including marking rules as remediable when Pixee should attempt an automatic fix.
+
+For worked examples of each flavor, see [`references/preferences-authoring.md`](references/preferences-authoring.md).
+Treat those examples as starting points and adapt them to the org's stack, tone, and
+compliance posture.
+
+## Examples
+
+```bash
+# Print the body verbatim, suitable for piping into an editor or less
+pixee organization preferences get --content-only
+
+# Pretty-print the record as JSON, then pull a single field with jq
+pixee organization preferences get --json | jq -r '.updated_by'
+
+# Walk to the canonical resource via HAL (do not hardcode the path)
+href=$(pixee organization preferences get --json | jq -r '._links.self.href')
+pixee api "$href"
+
+# Author offline and push from a file
+pixee organization preferences set --from-file ./pixee-preferences.md
+
+# Compose inline from a heredoc for a quick one-off
+pixee organization preferences set --content "$(cat <<'EOF'
+# Risk Guidance
+
+## SQL Injection
+Prefer Spring NamedParameterJdbcTemplate with :namedParameters.
+EOF
+)"
+
+# Round-trip through stdin (byte-identical when the transform is a no-op)
+pixee organization preferences get --content-only \
+  | sed 's/old-vendor/new-vendor/g' \
+  | pixee organization preferences set --from-file -
+
+# Retry the set on concurrent-modification conflicts
+until pixee organization preferences set --from-file ./pixee-preferences.md; do
+  echo "retrying"
+  sleep 1
+done
+```
+
+## Best practices
+
+- Author non-trivial preferences as a file (typically `pixee-preferences.md` in a repo root
+  or an internal docs repo) and push with `--from-file`. Reserve `--content` for one-liners
+  and shell heredocs.
+- Use `--content-only` when piping into editors, diffs, or `less`. Use `--output json` for
+  programmatic inspection and HAL traversal.
+- When composing preferences with help from external context (Notion pages, internal wikis,
+  MCP-connected knowledge bases), draft the candidate document, route it through a human
+  owner if the agent does not have authority to set org-wide policy, then push via
+  `--from-file` once approved.
+- Treat HTTP 412 as expected when multiple agents or humans edit concurrently. The friendly
+  retry message is the contract; loop the `set` call or refresh and re-author against the
+  latest content.
+- Repo-level `PIXEE.md` silently overrides org preferences for that repo. Agents working
+  inside a specific repository should check for `PIXEE.md` before assuming the org-level
+  document applies.

--- a/skills/pixee-preferences/references/preferences-authoring.md
+++ b/skills/pixee-preferences/references/preferences-authoring.md
@@ -1,0 +1,248 @@
+# Authoring Pixee organization preferences
+
+Reference examples for the three flavors of preference: remediation guidance, triage
+context, and rule enable/disable. Lift these directly when composing a preferences
+document, then adapt them to the org's stack, libraries, and tone.
+
+## Remediation guidance
+
+Tell Pixee how the team prefers to fix specific vulnerability classes. Code examples are
+the clearest signal: a "Preferred" block and a "Not preferred" block leave no ambiguity.
+
+### SQL injection in Java
+
+```markdown
+## SQL Injection
+
+When fixing SQL injection vulnerabilities, always use Spring's `NamedParameterJdbcTemplate`
+with named parameters (`:paramName` syntax) rather than positional placeholders (`?`).
+Named parameters improve code readability and make it easier to maintain queries with
+multiple parameters. This project includes `spring-jdbc` as a dependency.
+
+**Preferred approach:**
+```java
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+NamedParameterJdbcTemplate namedJdbc = new NamedParameterJdbcTemplate(dataSource);
+String query = "SELECT * FROM users WHERE email = :email";
+MapSqlParameterSource params = new MapSqlParameterSource("email", email);
+List<User> users = namedJdbc.query(query, params, rowMapper);
+```
+
+**Not preferred:**
+```java
+String query = "SELECT * FROM users WHERE email = ?";
+PreparedStatement stmt = conn.prepareStatement(query);
+stmt.setString(1, email);
+```
+```
+
+### Cross-site scripting in JavaScript
+
+```markdown
+## Cross-Site Scripting (XSS)
+
+For XSS vulnerabilities in user-generated content, always use the `DOMPurify` library for
+HTML sanitization. DOMPurify provides robust, battle-tested sanitization that prevents
+XSS while preserving the safe HTML formatting our content editors require.
+
+**Preferred approach:**
+```javascript
+const DOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+
+const window = new JSDOM('').window;
+const purify = DOMPurify(window);
+
+function renderUserContent(htmlContent) {
+    return purify.sanitize(htmlContent, {
+        ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a'],
+        ALLOWED_ATTR: ['href', 'class']
+    });
+}
+```
+
+**Not preferred:**
+```javascript
+function renderUserContent(htmlContent) {
+    return htmlContent
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+```
+```
+
+### Path traversal in C#
+
+```markdown
+## Path Traversal
+
+For path traversal vulnerabilities, always use our internal `PathValidatorUtility` class
+from the `DocumentManagement.Security` namespace rather than manual path validation or
+basic `Path.Combine` checks. `PathValidatorUtility` has been audited by our security team
+and enforces consistent path security policies across all file operations.
+
+**Preferred approach:**
+```csharp
+using DocumentManagement.Security;
+
+[HttpGet("download")]
+public IActionResult DownloadDocument([FromQuery] string filename)
+{
+    string safePath = PathValidatorUtility.ValidatePathForRead(filename);
+    byte[] fileBytes = System.IO.File.ReadAllBytes(safePath);
+    return File(fileBytes, "application/octet-stream", Path.GetFileName(safePath));
+}
+```
+
+**Not preferred:**
+```csharp
+using System.IO;
+
+[HttpGet("download")]
+public IActionResult DownloadDocument([FromQuery] string filename)
+{
+    string basePath = @"C:\Documents";
+    string fullPath = Path.Combine(basePath, filename);
+
+    if (!fullPath.StartsWith(basePath))
+    {
+        return BadRequest("Invalid path");
+    }
+
+    byte[] fileBytes = System.IO.File.ReadAllBytes(fullPath);
+    return File(fileBytes, "application/octet-stream", filename);
+}
+```
+```
+
+## Triage context
+
+Give Pixee context about the deployment environment, compensating controls, or
+intentional patterns so it can decide whether a finding is a real risk in this codebase.
+
+### Service architecture
+
+```markdown
+## Service Architecture and Trust Boundaries
+
+This service is a multi-tenant SaaS deployed behind AWS ALB with WAF enabled (XSS and
+SQL-injection rulesets active). Credentials are managed in AWS Secrets Manager; the
+application reads them from environment variables on startup. Rate limiting is enforced at
+both the ALB and application layers.
+
+Reduce severity by 1 level for findings on endpoints under `/api/internal/*` (IP-restricted
+to office and VPN ranges) and for methods annotated `@PreAuthorize("hasRole('ADMIN')")`.
+Findings in `@RestController` methods exposed at `/api/public/*` are higher priority than
+internal services: assume internet-facing attack surface.
+
+Treat data from external EHR systems as untrusted regardless of DTO type. Any class that
+extends `EHRMessageDTO` carries data from external integrations and should be treated as a
+taint source.
+```
+
+### SSRF allowlist
+
+```markdown
+## Server-Side Request Forgery (SSRF)
+
+For SSRF vulnerabilities in healthcare data fetching, validate URLs against our approved
+endpoint allowlists defined in `app.config`. Our medical data platform only integrates
+with pre-approved healthcare data exchange partners.
+
+**Approved Endpoints:**
+- Medical APIs: `APPROVED_MEDICAL_APIS` (HL7 FHIR, Healthcare.gov, etc.)
+- Internal systems: `INTERNAL_EHR_ENDPOINTS` (internal EHR instances)
+- Combined list: `ALL_APPROVED_ENDPOINTS`
+
+**Validation Rule:** URLs must start with one of the approved endpoint prefixes. Any
+other URL must be rejected with a clear error message directing users to the platform
+administration team.
+
+**Preferred approach:**
+```python
+from urllib.parse import urlparse
+from app.config import ALL_APPROVED_ENDPOINTS
+
+def fetch_patient_data(self, fhir_url: str) -> dict:
+    if not any(fhir_url.startswith(endpoint) for endpoint in ALL_APPROVED_ENDPOINTS):
+        raise ValueError(
+            f"API endpoint not in approved list: {fhir_url}. "
+            f"Contact platform admin to add new medical data sources."
+        )
+
+    parsed = urlparse(fhir_url)
+    if parsed.scheme != 'https':
+        raise ValueError("Only HTTPS endpoints allowed for medical data")
+
+    response = requests.get(fhir_url, timeout=30)
+    response.raise_for_status()
+    return response.json()
+```
+```
+
+### Intentional cryptographic patterns
+
+```markdown
+## Cryptography
+
+Treat any use of MD5 or SHA1 for password hashing or signature verification as
+**CRITICAL** (HIPAA requirement). Treat weak random number generation in session ID
+creation, token generation, or CSRF token generation as **CRITICAL**.
+
+The following uses of weak primitives are **intentional** and should be marked
+**FALSE_POSITIVE**:
+- Weak random in our rate-limiting jitter logic in `src/middleware/rate_limit.py`: this
+  is not a security context, the jitter only spreads request retries.
+- MD5 in `src/cache/keys.py`: used as a fast non-cryptographic content-addressable cache
+  key, never to authenticate or sign data.
+- SHA1 in `src/legacy/etag.py`: used as an ETag fingerprint for HTTP caching, not for
+  authentication.
+
+For password hashing, prefer Argon2id with our standard parameters (memory=64MB,
+iterations=3, parallelism=4). For cryptographically secure random, use
+`secrets.token_bytes()` in Python and `java.security.SecureRandom` in Java.
+```
+
+## Enabling and disabling rules
+
+Reference scanner rules by tool name and rule ID. Supported scanners today: Sonar,
+CodeQL, Semgrep, Checkmarx, Snyk, GitLab SAST, Veracode, AppScan, Polaris, Trivy, Datadog
+SAST, and Fortify.
+
+```markdown
+## Scanner Rule Preferences
+
+### Treat as remediable
+The Semgrep rule `python.lang.security.audit.eval-detected.eval-detected` should be
+considered **REMEDIABLE**. We have a safe eval wrapper pattern that can be applied
+automatically; do not mark findings of this rule as WONT_FIX by default.
+
+### Disable
+Ignore findings for these rules across all repos:
+- Sonar `javasecurity:S2076` in `src/scripts/admin/`: internal CLI tooling, not exposed.
+- CodeQL `js/disabled-certificate-validation` in `test/`: TLS validation is disabled
+  against the test fixture server only.
+- Snyk `javascript/PrototypePollution` flagged on `devDependencies`: these never ship to
+  production bundles.
+
+### Elevate
+Promote these rule classes by one severity level when found in `/src/payments/` (PCI-DSS
+scope): all CodeQL `cwe-`-prefixed rules and any Sonar rule whose key starts with
+`security-hotspot:`.
+```
+
+## Composing a document
+
+- Start small. A handful of high-impact rules and one or two triage paragraphs cover most
+  real-world cases.
+- Explain *why* a preference exists. The "why" lets Pixee apply the rule correctly to new
+  findings instead of pattern-matching on the prose.
+- Show code where possible. Plain prose works, but a "Preferred" code block paired with a
+  "Not preferred" counter-example is unambiguous.
+- Keep total length under 10,000 characters. The CLI rejects oversize content client-side
+  before the round-trip.
+- Treat the document as living. Update it when the stack changes, when a recurring
+  false-positive pattern emerges, or when a new internal utility supersedes an old one.


### PR DESCRIPTION
Adds a `pixee-preferences` agent skill that documents the new `pixee organization preferences get` and `set` subcommands so coding agents drive them natively instead of hand-rolling `pixee api` calls and an ETag dance. The skill covers the CLI surface (flags, exit codes, the 204-on-fresh-org branch, the friendly 412 conflict message) and points at a sidecar reference under `references/preferences-authoring.md` that captures worked examples of remediation guidance, triage context, and rule enable/disable so agents have a starting template when composing a preferences document.

The sidecar is the first reference document in the skills tree. It is justified by the volume of pedagogical content (seven worked examples lifted from the analysis-service preferences fixtures), which would crowd the CLI-surface documentation in `SKILL.md` if inlined. `npx skills add . --list` shows the new skill rendering correctly with its full description in the interactive picker.

/close ISS-7141