### PR TITLE
📝 Document Repo View and Delete Subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ individual skills directly with `npx skills add pixee/pixee-cli --skill <name>`:
 - [`pixee-api`](./skills/pixee-api/SKILL.md) — the `pixee api` escape hatch and HAL discovery.
 - [`pixee-preferences`](./skills/pixee-preferences/SKILL.md) — read and write Pixee organization
   preferences from files or stdin.
-- [`pixee-repo`](./skills/pixee-repo/SKILL.md) — `pixee repo list` and the shared `--repo`
-  resolution protocol.
+- [`pixee-repo`](./skills/pixee-repo/SKILL.md) — `pixee repo list`, `view`, `delete`, and the
+  shared `--repo` resolution protocol.
 - [`pixee-scan`](./skills/pixee-scan/SKILL.md) — `pixee scan list` and `pixee scan get`, with
   filters for repository, branch, detector tool, and analysis state.
 - [`pixee-finding`](./skills/pixee-finding/SKILL.md) — `pixee finding list` (with `--stats` and

--- a/skills/pixee-repo/SKILL.md
+++ b/skills/pixee-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pixee-repo
-description: "List Pixee repositories and resolve repository names to UUIDs."
+description: "List, view, and delete Pixee repositories with shared name-or-UUID resolution used by every targeted subcommand."
 metadata:
   version: 1.0.0
   openclaw:
@@ -17,14 +17,14 @@ metadata:
 > handling. Those conventions apply to every command in this skill. See `../pixee-auth/SKILL.md`
 > if authentication needs to be configured.
 
-`pixee repo` lists repositories registered with the Pixee platform and documents the `--repo`
-resolution protocol used by every other subcommand that targets a specific repository.
+`pixee repo` manages repositories registered with the Pixee platform: list, view, and delete. It
+also documents the `--repo` resolution protocol used by every other subcommand that targets a
+specific repository.
 
-## Commands
-
-### pixee repo list
+## pixee repo list
 
 List registered repositories. Pagination is transparent — the CLI walks every page automatically.
+Text output is tab-separated with columns `name`, `full_name`, `type`, `default_branch`, `id`.
 
 Flags:
 
@@ -36,6 +36,39 @@ Flags:
 Each repository has a `type` discriminator (`github`, `gitlab`, `azure`, `git`, `bitbucket`), a
 UUID `id`, a `name`, a `full_name` (e.g., `pixee/pixee-platform`), and a `default_branch`.
 Type-specific fields (`owner`, `html_url` for GitHub, etc.) appear only in `--output json`.
+
+## pixee repo view
+
+```
+pixee repo view <repo-id>
+```
+
+Fetch a single repository by UUID. `<repo-id>` is the value shown in the `id` column of
+`pixee repo list`.
+
+Default text mode prints a sectioned `Key: value` block of the common fields shared by every
+git-provider variant — `Name`, `Full name`, `Default branch`, `Type`, `ID` — colon-separated, one
+field per line. Use `--output json` (or `--json`) for the full HAL body, which adds the
+provider-specific fields (`github_app_installation_id` for GitHub, `azure_project` for Azure
+DevOps, etc.) and the `_links` envelope. The text view intentionally omits the provider-specific
+fields because the union over five integration types would render inconsistently; reach for
+`--json` when an agent needs them.
+
+A non-existent UUID returns the standard not-found error and exits 3.
+
+## pixee repo delete
+
+```
+pixee repo delete <repo-id>
+```
+
+Delete a repository by UUID. **Cascading:** the server also removes the repository's scans,
+workflows, and findings as part of the same operation, so this is more destructive than the verb
+name suggests. On success the CLI prints `Deleted repo <id>` and exits 0; a missing repo exits 3.
+
+There is no confirmation prompt — `pixee` does not ship interactive guards for any destructive
+verb (`scan delete`, `workflow delete`, `repo delete` all behave the same way). Scripts that want
+a guard should add their own check before calling.
 
 ## Repository name resolution
 
@@ -69,6 +102,16 @@ pixee repo list --output json | jq '.[] | select(.type == "github") | .full_name
 # Filter server-side to reduce payload
 pixee repo list --name pixee-platform
 
+# Inspect a single repo's common fields in text mode
+pixee repo view a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+
+# Pull the full HAL body to see provider-specific fields like github_app_installation_id
+pixee repo view a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d --json \
+  | jq '{type, full_name, github_app_installation_id}'
+
+# Delete a repository by UUID (also removes its scans, workflows, and findings)
+pixee repo delete a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+
 # Ambiguous --repo: the CLI prints each match with its UUID; retry with the UUID
 pixee workflow list --repo pixee-platform
 # Error: Multiple repositories named "pixee-platform":
@@ -83,3 +126,7 @@ pixee workflow list --repo pixee-platform
 - When scripting across many repositories, use UUIDs: they are stable under rename and never
   ambiguous.
 - Pagination is transparent on `pixee repo list`; `--paginate` exists only on `pixee api`.
+- Reach for `pixee repo view --json` when an agent needs provider-specific fields; the default
+  text view is intentionally pared down to the fields every integration shares.
+- `pixee repo delete` cascades to scans, workflows, and findings server-side. Confirm scope (and
+  any depending scripts) before running it; there is no client-side confirmation prompt.


### PR DESCRIPTION
The pixee CLI 0.13.0 release added `pixee repo view <id>` and `pixee repo delete <id>` alongside the existing `pixee repo list`. The audit-skills workflow caught the corresponding skill drift: `pixee-repo` only documented `list`, so an agent asked to inspect a single repo or remove one had no skill to ground on and would fall back to guessing or to `pixee api -X DELETE`.

This PR extends `skills/pixee-repo/SKILL.md` to cover the two new verbs. The skill moves to the H2-per-subcommand structure adopted in `pixee-finding` and `pixee-preferences` so all three sections sit at the same level instead of being nested under a `## Commands` H2. The new `pixee repo view` section explains the sectioned text-mode output and the JSON-mode provider-specific fields (`github_app_installation_id` for GitHub, `azure_project` for Azure DevOps, and so on). The new `pixee repo delete` section calls out the server-side cascade to scans, workflows, and findings and the absence of any client-side confirmation prompt, mirroring the destructive-verb voice already used in `pixee-workflow`.

Three runnable examples are added to the existing examples block, and two best-practices bullets capture the rules of thumb — reach for `--json` when provider-specific fields are needed, and confirm scope before running `repo delete`. The picker description is rewritten verb-first to "List, view, and delete Pixee repositories with shared name-or-UUID resolution used by every targeted subcommand." (112 characters, no picker-breaking punctuation). The README bullet is refreshed to match.

/close ISS-7251