### PR TITLE
📝 Document Workflow Run Subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ individual skills directly with `npx skills add pixee/pixee-cli --skill <name>`:
 - [`pixee-finding`](./skills/pixee-finding/SKILL.md) — `pixee finding list` (with `--stats` and
   filters across triage, fix, sca) and `pixee finding view`, scoped to a scan with per-finding
   analysis results inlined.
-- [`pixee-workflow`](./skills/pixee-workflow/SKILL.md) — workflow list/create/update/delete,
+- [`pixee-workflow`](./skills/pixee-workflow/SKILL.md) — workflow list/create/update/run/delete,
   event kinds, severity filters, and partial-update semantics.

--- a/skills/pixee-workflow/SKILL.md
+++ b/skills/pixee-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pixee-workflow
-description: "List, create, update, and delete Pixee workflows on a repository."
+description: "List, create, update, run, and delete Pixee workflows on a repository with partial-update semantics across event kinds."
 metadata:
   version: 1.0.0
   openclaw:
@@ -17,7 +17,7 @@ metadata:
 > handling, `../pixee-auth/SKILL.md` if authentication needs to be configured, and
 > `../pixee-repo/SKILL.md` for the `--repo` resolution protocol.
 
-`pixee workflow` manages Pixee workflows for a single repository: list, create, update, and
+`pixee workflow` manages Pixee workflows for a single repository: list, create, update, run, and
 delete.
 
 ## pixee workflow list
@@ -111,6 +111,23 @@ Every `update` subcommand also accepts:
   Action-scoped fields (`severity-labels`, `min/max-severity-score`, `min-fix-confidence`,
   `finding-limit`) require `--action create-patch` on the same call, even when only unsetting.
 
+## pixee workflow run
+
+```
+pixee workflow run <workflow-id>
+```
+
+Trigger a scheduled workflow on demand. `<workflow-id>` is the UUID shown in the `id` column of
+`pixee workflow list`.
+
+`run` targets `schedule` workflows specifically — `new-scan` and `pull-request-scan` workflows
+fire on their own events (incoming scan, pull-request scan) and there is nothing for the agent
+to trigger manually. Pairs naturally with `pixee workflow update schedule --enabled` for the
+"re-enable, then kick off once now" flow, and with `--disabled` to suspend the cadence after a
+single manual run.
+
+No flags. No `--repo` flag — the workflow UUID disambiguates by itself.
+
 ## pixee workflow delete
 
 ```
@@ -161,6 +178,10 @@ pixee workflow update schedule a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d \
 
 # Delete a workflow by UUID
 pixee workflow delete a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+
+# Re-enable a paused schedule workflow, then trigger it once on demand
+pixee workflow update schedule a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d --enabled
+pixee workflow run a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 ```
 
 ## Best practices
@@ -179,3 +200,6 @@ pixee workflow delete a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 - `--enabled` and `--disabled` are mutually exclusive on `update`; pass at most one per call.
 - The `update` subcommand must match the workflow's existing event kind. To change event kind,
   delete and recreate.
+- `pixee workflow run` only makes sense for `schedule` workflows; `new-scan` and
+  `pull-request-scan` workflows fire on their own events. Use `run` for the "re-enable, then
+  trigger once now" or "kick off the cadence ahead of schedule" patterns.


### PR DESCRIPTION
The pixee CLI 0.13.0 release added `pixee workflow run <id>` for triggering a scheduled workflow on demand. The audit-skills workflow caught the corresponding skill drift: `pixee-workflow` documented list, create, update, and delete but not run, so an agent asked to kick off a schedule after re-enabling it had no skill grounding.

This PR extends `skills/pixee-workflow/SKILL.md` with a new `## pixee workflow run` section placed between `update` and `delete` in the natural workflow lifecycle. The section calls out that `run` targets `schedule` workflows specifically — `new-scan` and `pull-request-scan` workflows fire on their own events and have nothing for the agent to trigger manually — and that the verb pairs naturally with `update schedule --enabled` for the "re-enable, then trigger once now" pattern. A two-line example joins the existing examples block showing exactly that pairing, and a best-practices bullet captures the schedule-only constraint along with the common patterns.

The picker description is rewritten verb-first to "List, create, update, run, and delete Pixee workflows on a repository with partial-update semantics across event kinds." (119 characters, no picker-breaking punctuation). The README bullet is refreshed to match.

/close ISS-7252