### PR TITLE
📝 Document Enterprise TLS Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ pixee workflow list --repo my-repo
 
 Run `pixee --help` to see every subcommand.
 
+## TLS verification
+
+The CLI verifies the server's TLS certificate against Bun's bundled Mozilla CA list — not the operating system's trust
+store. Installing a private CA in your OS keychain alone is not enough; Bun will not consult it unless you opt in (see
+the reference below). When connecting to a Pixee Enterprise Server that presents a certificate signed by an internal
+CA, you have two options:
+
+**Trust the internal CA (preferred).** Point `NODE_EXTRA_CA_CERTS` at a PEM file containing the CA chain. Verification
+still happens — only your specific CA is added to the trust set, so the bearer token is still protected from passive
+eavesdroppers and active on-path attackers.
+
+```sh
+NODE_EXTRA_CA_CERTS=/etc/ssl/internal-ca.pem pixee --server https://pixee.internal scan list
+```
+
+**Skip verification entirely (last resort).** Pass `--insecure` or set `PIXEE_INSECURE_TLS=true`. A warning is printed
+to stderr on every invocation so the choice stays visible in CI logs. Do not use this in production: a passive
+eavesdropper or active on-path attacker can intercept the request and read your bearer token.
+
+```sh
+pixee --insecure --server https://pixee.internal scan list
+PIXEE_INSECURE_TLS=true pixee --server https://pixee.internal scan list
+```
+
+See [Bun's `tls.getCACertificates` reference](https://bun.com/reference/node/tls/getCACertificates) for the full chain
+loading order (bundled Mozilla CAs → system keychain when `NODE_USE_SYSTEM_CA=1` → `NODE_EXTRA_CA_CERTS` extras) and
+[Node's `NODE_EXTRA_CA_CERTS` docs](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) for the env-var contract
+Bun inherits.
+
 ## Coding agent skills
 
 The Pixee CLI ships with [skills.sh](https://skills.sh)-formatted skills that teach coding agents

--- a/README.md
+++ b/README.md
@@ -45,32 +45,42 @@ pixee workflow list --repo my-repo
 
 Run `pixee --help` to see every subcommand.
 
-## TLS verification
+## TLS configuration
 
-The CLI verifies the server's TLS certificate against Bun's bundled Mozilla CA list — not the operating system's trust
-store. Installing a private CA in your OS keychain alone is not enough; Bun will not consult it unless you opt in (see
-the reference below). When connecting to a Pixee Enterprise Server that presents a certificate signed by an internal
-CA, you have two options:
+To point `pixee` at a Pixee Enterprise Server with a privately signed certificate, configure trust through one of the
+options below. `pixee` verifies certificates against its bundled Mozilla CA list, not the operating system's trust
+store, so installing the CA in your OS keychain alone won't make the connection succeed.
 
-**Trust the internal CA (preferred).** Point `NODE_EXTRA_CA_CERTS` at a PEM file containing the CA chain. Verification
-still happens — only your specific CA is added to the trust set, so the bearer token is still protected from passive
-eavesdroppers and active on-path attackers.
+### Add the internal CA to `pixee`'s trust set (recommended)
+
+Set `NODE_EXTRA_CA_CERTS` to a PEM file containing the chain. Verification still happens; only your specific CA is
+added to the trust set, so the bearer token stays protected from passive eavesdroppers and on-path attackers.
 
 ```sh
 NODE_EXTRA_CA_CERTS=/etc/ssl/internal-ca.pem pixee --server https://pixee.internal scan list
 ```
 
-**Skip verification entirely (last resort).** Pass `--insecure` or set `PIXEE_INSECURE_TLS=true`. A warning is printed
-to stderr on every invocation so the choice stays visible in CI logs. Do not use this in production: a passive
-eavesdropper or active on-path attacker can intercept the request and read your bearer token.
+For a persistent setup, export the variable from your shell profile or set it in your deployment environment (CI
+variable, container env, Kubernetes secret, etc.).
+
+### Disable verification (last resort)
+
+If you genuinely cannot obtain the CA chain (short-lived sandbox, one-off connectivity check, ephemeral CI container
+with no way to mount a PEM), pass `--insecure` or set `PIXEE_INSECURE_TLS=true` to skip certificate verification
+entirely. A warning prints to stderr on every invocation so the choice stays visible in CI logs.
 
 ```sh
 pixee --insecure --server https://pixee.internal scan list
 PIXEE_INSECURE_TLS=true pixee --server https://pixee.internal scan list
 ```
 
-See [Bun's `tls.getCACertificates` reference](https://bun.com/reference/node/tls/getCACertificates) for the full chain
-loading order (bundled Mozilla CAs → system keychain when `NODE_USE_SYSTEM_CA=1` → `NODE_EXTRA_CA_CERTS` extras) and
+Avoid this in production: with verification off, anyone who can intercept the connection can read your bearer token
+and act as you against the API. Treat any persistent CI usage as a bug to come back and fix once the CA is available.
+
+### Reference
+
+See [Bun's `tls.getCACertificates`](https://bun.com/reference/node/tls/getCACertificates) for the full chain loading
+order (bundled Mozilla CAs → system keychain when `NODE_USE_SYSTEM_CA=1` → `NODE_EXTRA_CA_CERTS` extras) and
 [Node's `NODE_EXTRA_CA_CERTS` docs](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) for the env-var contract
 Bun inherits.
 

--- a/skills/pixee-shared/SKILL.md
+++ b/skills/pixee-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: pixee-shared
 description: "Describe the global flags, output format, exit codes, and error handling used by every Pixee CLI subcommand."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   openclaw:
     category: "developer-tools"
     requires:
@@ -50,6 +50,11 @@ server-precedence rules, and `pixee auth status` — see `pixee-auth`.
   suitable for `grep`/`awk`). Use `json` for machine-readable output and pipe to `jq` for
   filtering; `pixee` does not embed a jq implementation.
 - `--json` — shorthand for `--output json`.
+- `--insecure` — skip TLS certificate verification for the invocation (also enabled by
+  `PIXEE_INSECURE_TLS=true`). Prints a warning to stderr on every invocation. Last-resort escape
+  hatch for connecting to a Pixee Enterprise Server with a privately signed certificate; prefer
+  `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` to add the internal CA to the trust set without disabling
+  verification. See the project README for the full trust-store story.
 
 ## Exit codes
 

--- a/skills/pixee-shared/SKILL.md
+++ b/skills/pixee-shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pixee-shared
-description: "Describe the global flags, output format, exit codes, and error handling used by every Pixee CLI subcommand."
+description: "Describe the global flags, output format, exit codes, error handling, and TLS trust troubleshooting used by every Pixee CLI subcommand."
 metadata:
   version: 1.1.0
   openclaw:

--- a/skills/pixee-shared/SKILL.md
+++ b/skills/pixee-shared/SKILL.md
@@ -51,10 +51,9 @@ server-precedence rules, and `pixee auth status` — see `pixee-auth`.
   filtering; `pixee` does not embed a jq implementation.
 - `--json` — shorthand for `--output json`.
 - `--insecure` — skip TLS certificate verification for the invocation (also enabled by
-  `PIXEE_INSECURE_TLS=true`). Prints a warning to stderr on every invocation. Last-resort escape
-  hatch for connecting to a Pixee Enterprise Server with a privately signed certificate; prefer
-  `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` to add the internal CA to the trust set without disabling
-  verification. See the project README for the full trust-store story.
+  `PIXEE_INSECURE_TLS=true`). Prints a warning to stderr. Last resort for connecting to a Pixee
+  Enterprise Server with a privately signed certificate — see **TLS trust failures** below for the
+  preferred fix.
 
 ## Exit codes
 
@@ -82,3 +81,13 @@ With `--output json`, the raw document is passed through unchanged.
 
 Authentication failures exit with code 2. Not-found responses exit with code 3. Other problem
 responses exit with code 1.
+
+## TLS trust failures
+
+`pixee` verifies certificates against its bundled Mozilla CA list, not the operating system's
+trust store. When the user reports that `pixee` cannot reach an internal or enterprise Pixee
+Server and the generic "Connection to ... failed" message looks like it might be a certificate
+problem, read [`references/tls-troubleshooting.md`](./references/tls-troubleshooting.md). It
+covers: confirming with `curl` that it's a trust failure (not DNS or a wrong URL), the preferred
+fix (`NODE_EXTRA_CA_CERTS` pointing at the internal CA PEM), and `--insecure` as a last resort
+with the security tradeoff to surface to the user.

--- a/skills/pixee-shared/references/tls-troubleshooting.md
+++ b/skills/pixee-shared/references/tls-troubleshooting.md
@@ -1,0 +1,81 @@
+# TLS trust failures
+
+Read this when the user reports that `pixee` cannot reach an internal or
+enterprise Pixee server and the failure looks like a certificate problem (the
+generic "Connection to ... failed" message is the symptom — confirm with
+`curl` before applying anything below).
+
+`pixee` verifies the server's TLS certificate against its bundled Mozilla CA
+list, not the operating system's trust store. Installing a private CA in the
+OS keychain alone does not change what `pixee` trusts. This bites when the
+user is connecting to a self-hosted Pixee Enterprise Server whose certificate
+is signed by an internal CA: the request fails before any HTTP traffic.
+
+## Confirm it's a trust issue
+
+The CLI's "Connection to ... failed" line covers DNS failures, connection
+refused, and TLS failures alike, so the first job is to confirm what's
+actually broken. Don't guess — run a one-shot probe with `curl` from the
+same shell and read its error verbatim:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' https://pixee.<internal-domain>/
+```
+
+If `curl` reports `SSL certificate problem: self-signed certificate`,
+`unable to get local issuer certificate`, or similar, it's a CA-chain problem
+and the steps below apply. If `curl` says `Could not resolve host`,
+`Connection refused`, or times out, this guide isn't the fix — that's DNS,
+firewall, or a wrong `--server` URL.
+
+## Preferred fix — add the internal CA to `pixee`'s trust set
+
+`pixee` honors `NODE_EXTRA_CA_CERTS`. Point it at a PEM file containing the
+internal CA chain and verification still happens — only that specific CA is
+added. The user's bearer token stays protected from passive eavesdroppers
+and active on-path attackers, which is exactly what you want.
+
+Walk the user through this:
+
+1. **Locate the internal CA PEM.** Ask the user — they usually have it from
+   their IT team, an internal docs page, or by running
+   `openssl s_client -connect pixee.<internal-domain>:443 -showcerts </dev/null`
+   and copying the chain. If they don't have it and can't get it quickly,
+   drop to the last-resort fix.
+2. **Verify it covers the server.** With the PEM on disk, confirm `curl`
+   itself trusts it before touching `pixee`:
+   ```bash
+   curl --cacert /path/to/internal-ca.pem https://pixee.<internal-domain>/
+   ```
+   A successful response means the chain is right. A continued
+   `unable to get local issuer certificate` means the file is missing
+   intermediates — ask for the full chain.
+3. **Run `pixee` against it.** Set the env var in the same shell:
+   ```bash
+   export NODE_EXTRA_CA_CERTS=/path/to/internal-ca.pem
+   pixee --server https://pixee.<internal-domain> auth status
+   ```
+   For a persistent setup, export it from the user's shell profile or set it
+   in the deployment's environment (CI variable, Kubernetes secret, etc.).
+   Per-invocation works too:
+   ```bash
+   NODE_EXTRA_CA_CERTS=/path/to/internal-ca.pem pixee --server https://... scan list
+   ```
+
+## Last resort — `--insecure`
+
+If the user genuinely cannot obtain the CA chain (short-lived sandbox,
+one-off connectivity check, ephemeral CI container with no way to mount a
+PEM), `--insecure` / `PIXEE_INSECURE_TLS=true` disables verification entirely:
+
+```bash
+pixee --insecure --server https://pixee.<internal-domain> scan list
+PIXEE_INSECURE_TLS=true pixee --server https://pixee.<internal-domain> scan list
+```
+
+Be explicit with the user about the tradeoff before suggesting it: with
+verification off, anyone who can intercept the connection — including any
+host between them and the server — can read their bearer token and act as
+them against the API. Recommend it only when the cost of waiting for the
+proper CA is genuinely higher than that risk, and treat any persistent CI
+usage of `--insecure` as a bug to come back and fix once the CA is available.


### PR DESCRIPTION
Documents how the Pixee CLI verifies TLS certificates and how to configure it for enterprise deployments. `NODE_EXTRA_CA_CERTS` is the preferred fix (internal CA added to the trust set, verification still happens); `--insecure` / `PIXEE_INSECURE_TLS=true` is the last-resort bypass.

- Adds a `TLS verification` section to `README.md`
- Bumps `pixee-shared` to 1.1.0 with `--insecure` in the global-flags list and a new `references/tls-troubleshooting.md` sidecar that walks an agent through diagnosing the failure with `curl` and applying the preferred fix before falling back to `--insecure`

/towards ISS-7275