### PR TITLE
📝 Document Release Artifact Checksum Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ Pre-compiled binaries for `linux-x64`, `darwin-arm64`, and `windows-x64` are pub
 assets on each [GitHub Release](https://github.com/pixee/pixee-cli/releases/latest). Download the archive
 for your platform, extract the `pixee` binary, and place it on your `PATH`.
 
+### Verifying your download
+
+Each release publishes a `SHA256SUMS` manifest listing the checksum of every archive. Download it into the
+same directory as your archive, then confirm the archive matches its published checksum:
+
+```bash
+# Linux
+sha256sum --ignore-missing -c SHA256SUMS
+
+# macOS
+shasum -a 256 --ignore-missing -c SHA256SUMS
+```
+
+`--ignore-missing` checks only the archives you actually downloaded; a line ending in `OK` confirms a match.
+
 ## Getting started
 
 ```bash

--- a/skills/pixee-shared/SKILL.md
+++ b/skills/pixee-shared/SKILL.md
@@ -27,6 +27,15 @@ brew install pixee
 pixee --version   # prints the release version baked into the binary
 ```
 
+When downloading an archive directly, verify it against the `SHA256SUMS` manifest published on the
+release before extracting the binary. Download the manifest into the same directory as the archive,
+then check it (`--ignore-missing` limits the check to the archives actually downloaded):
+
+```bash
+sha256sum --ignore-missing -c SHA256SUMS      # Linux
+shasum -a 256 --ignore-missing -c SHA256SUMS  # macOS
+```
+
 ## Credentials at a glance
 
 `pixee` reads an API token and server URL from environment variables (`PIXEE_TOKEN`,


### PR DESCRIPTION
- Add a "Verifying your download" step to the README install section and the `pixee-shared` skill so users and coding agents verify a directly-downloaded archive against the `SHA256SUMS` manifest published on each release before extracting the binary.
- Verification uses the portable `sha256sum -c` and `shasum -a 256 -c` check with `--ignore-missing`, so it works even when only one archive was downloaded.

/towards ISS-8092
