### PR TITLE
📝 Fix The Homebrew Install Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Claude Code and OpenAI Codex can drive it natively.
 ### Homebrew (macOS and Linux)
 
 ```bash
-brew tap pixee/pixee
-brew install pixee
+brew install pixee/tap/pixee
 ```
 
 ### Direct download


### PR DESCRIPTION
The documented Homebrew install installs nothing. From a clean machine:

```
$ brew tap pixee/pixee
==> Tapping pixee/pixee
Cloning into '/opt/homebrew/Library/Taps/pixee/homebrew-pixee'...
Tapped 1 formula (18 files, 54.9KB).

$ brew install pixee
Error: Refusing to load formula pixee/pixee/pixee from untrusted tap pixee/pixee.
```

Step one succeeds and gives no hint of a problem, so this surfaces at step two as what looks like a security error rather than a stale instruction.

Two causes:

1. `pixee/homebrew-pixee` was renamed to `pixee/homebrew-tap`, so `pixee/pixee` resolves through a GitHub redirect and installs a second tap for the same repo. With both present the short name is ambiguous: `Error: Formulae found in multiple taps`.
2. Since Homebrew 6.0.0 a non-official tap must be trusted before Homebrew will load a formula from it by short name.

`brew install pixee/tap/pixee` fixes both. Correct tap, and installing by fully qualified name trusts that one formula, so no `brew trust` step is needed:

```
==> Tapping pixee/tap
==> Trusted formula pixee/tap/pixee
==> Installing pixee from pixee/tap
🍺  /opt/homebrew/Cellar/pixee/0.17.0: 4 files, 63.7MB
```

Both paths were run from a fully reset state (no binary, no taps, empty trust file) rather than reasoned about: the old instructions install nothing, the new one yields `pixee 0.17.0` from a single tap.

The trust mechanics are deliberately not explained in the README. A reader installing the CLI does not need Homebrew's trust model, only a command that works, and Homebrew's own error message points anyone who needs it at `brew trust`.

The customer-facing copy in pixee/docs `docs/api/cli.md` has the same two-line block and the same bug. That page is already being rewritten in pixee/docs#295, so it belongs there.
