### PR TITLE
📝 Sync Pixee Skills with the 0.17.0 CLI Surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,5 +147,5 @@ individual skills directly with `npx skills add pixee/pixee-cli --skill <name>`:
 - [`pixee-finding`](./skills/pixee-finding/SKILL.md) — `pixee finding list` (with `--stats` and
   filters across triage, fix, sca) and `pixee finding view`, scoped to a scan with per-finding
   analysis results inlined.
-- [`pixee-workflow`](./skills/pixee-workflow/SKILL.md) — workflow list/create/update/run/delete,
+- [`pixee-workflow`](./skills/pixee-workflow/SKILL.md) — workflow list/view/create/update/run/delete,
   event kinds, severity filters, and partial-update semantics.

--- a/skills/pixee-analysis/SKILL.md
+++ b/skills/pixee-analysis/SKILL.md
@@ -2,7 +2,7 @@
 name: pixee-analysis
 description: "List, view, and delete Pixee analyses with filters and optional polling until the analysis reaches a terminal state."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   openclaw:
     category: "developer-tools"
     requires:
@@ -43,6 +43,8 @@ Filter flags:
 
 - `--repo <name-or-uuid>` — **repeatable**. Restrict to one or more repositories. Names resolve
   via the protocol documented in `pixee-repo`. Multiple `--repo` flags OR together.
+- `--scan <scan-id>` — **repeatable**. Restrict to one or more scan UUIDs. Multiple `--scan`
+  flags OR together.
 - `--branch <name>` — exact branch name (case-sensitive).
 - `--state <state>` — **repeatable**. One of `queued`, `in-progress`, `skipped`, `completed`,
   `failed`. Multiple values OR together.
@@ -106,6 +108,9 @@ pixee analysis list --repo pixee/pixee-platform --repo analysis-service \
 # Completed sonar analyses, JSON for downstream processing
 pixee analysis list --tool sonar --state completed --json \
   | jq '.[] | {id, state, updated_at}'
+
+# Analyses for a specific scan
+pixee analysis list --scan e5e1ebe6-93f3-4426-a98a-6dc6af41b468
 
 # View an analysis by UUID
 pixee analysis view 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d

--- a/skills/pixee-finding/SKILL.md
+++ b/skills/pixee-finding/SKILL.md
@@ -2,7 +2,7 @@
 name: pixee-finding
 description: "List, filter, and view Pixee findings for a scan with aggregate counts across triage, fix, and SCA outcomes."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   openclaw:
     category: "developer-tools"
     requires:
@@ -74,21 +74,25 @@ the same flag.
 - `--min-severity-score <num>` / `--max-severity-score <num>` — bound the severity score (0.0–10.0).
   Not repeatable.
 - `--triage-status <s>` — one of `completed`, `failed`, `no-recommendations-available`.
-- `--triage-suggested <s>` — one of `true_positive`, `likely_true_positive`, `inconclusive`,
-  `false_positive`, `wont_fix`, `blocked`, `excluded`, `not_triaged`.
+- `--triage-suggested <s>` — one of `true_positive`, `inconclusive`, `false_positive`, `wont_fix`,
+  `blocked`, `excluded`, `not_triaged`, `error`, `suspicious`.
 - `--fix-status <s>` — one of `completed`, `failed`, `no-recommendations-available`, `blocked`,
   `excluded`.
 - `--fix-confidence <s>` — one of `high`, `medium`, `low`, `no-rating`.
 - `--sca-status <s>` — one of `completed`, `failed`, `blocked`, `excluded`, `not-analyzed`.
-- `--sca-classification <s>` — one of `exploitable`, `not-exploitable`, `inconclusive`.
+- `--sca-classification <s>` — one of `exploitable`, `not-exploitable`, `inconclusive`,
+  `potentially-exploitable`.
 - `--patch-status <s>` — one of `issued`, `merged`.
 - `--severity-update <s>` — one of `increased`, `decreased`, `no_update`. Filters by the
   severity-update relation.
 - `--analyzed` — only fully-analyzed findings (every analysis type has reached a terminal state).
 - `--no-analyzed` — only not-fully-analyzed findings.
 - `--view validated` — composite view filter. Currently only `validated` is defined.
+- `--results <scope>` — **repeatable**. Analysis results to include per finding. One of
+  `representative` (default) or `all`.
 - `--query <text>` — case-insensitive search across finding id, title, rule, and file path.
-- `--sort <field>` — `pixee-intelligence` (default), `severity`, or `pixee-severity`.
+- `--sort <field>` — `pixee-intelligence` (default), `severity`, `pixee-severity`, or
+  `suggested-severity`.
 - `--order <asc|desc>` — sort direction. Default `desc`.
 
 ## pixee finding view

--- a/skills/pixee-integration/SKILL.md
+++ b/skills/pixee-integration/SKILL.md
@@ -2,7 +2,7 @@
 name: pixee-integration
 description: "List Pixee integrations to discover the id, type, and capabilities of each scanner integration registered with the org."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   openclaw:
     category: "developer-tools"
     requires:
@@ -52,6 +52,29 @@ distinguishes scan kinds at a finer grain (e.g., `polaris_sast` vs `polaris_sca`
 `gitlab_sast` vs `gitlab_dependency_scanning`), while the integration `type` collapses to the
 provider family.
 
+Filter flags:
+
+- `--search <text>` — substring match against integration metadata (server-side).
+- `--type <type>` — filter by integration type. One of `appscan`, `arnica`, `azure`, `bitbucket`,
+  `checkmarx`, `datadog`, `github`, `gitlab`, `polaris`, `sonar`, `veracode`.
+
+## pixee integration view
+
+```
+pixee integration view <integration-id>
+```
+
+Fetch a single integration by ID. `<integration-id>` is the value shown in the `id` column of
+`pixee integration list`.
+
+Default text mode emits a sectioned `Key: value` block; use `--output json` (or `--json`) for the
+full HAL body. An `Expand:` line names the relations the integration offers via its `_links`.
+
+- `--expand <relation>` — **repeatable**. Follow one of the integration's `_links` and render it
+  inline, saving a second `pixee api` call. Pass the relation name shown on the `Expand:` line.
+
+A non-existent ID returns the standard not-found error and exits 3.
+
 ## Examples
 
 ```bash
@@ -61,8 +84,20 @@ pixee integration list
 # JSON shape for programmatic consumption
 pixee integration list --json | jq '.[] | {id, type, capabilities}'
 
+# Filter to GitHub integrations only, server-side
+pixee integration list --type github
+
+# Substring search against integration metadata
+pixee integration list --search sonar
+
 # Find integrations that can push triage verdicts back to the source
 pixee integration list --json | jq '.[] | select(.capabilities | index("triage-push"))'
+
+# Inspect a single integration by ID
+pixee integration view sonar-default
+
+# Follow one of the integration's expandable relations inline (see its Expand: line for names)
+pixee integration view sonar-default --expand <relation>
 
 # Discover the sonar integration id and use it in a scan-create call
 integration_id=$(pixee integration list --json \
@@ -83,7 +118,8 @@ pixee api "$href"
   `<type>-default` string by hand, since that pattern is a convention the platform can change.
 - Filter by `type` when looking for a specific scanner family. The org may have multiple
   integrations of the same type (different GitHub Apps, multiple GitLab tenants) and `type`
-  alone is not unique.
+  alone is not unique. `--search` and `--type` are both server-side, so prefer them over
+  post-filtering `list --json` in `jq`.
 - Read `capabilities` before assuming an integration can do more than receive uploads.
   `triage-push` is the load-bearing one today; treat the array as forward-compatible and check
   for membership (`jq '.capabilities | index("...")'`) rather than equality.

--- a/skills/pixee-shared/SKILL.md
+++ b/skills/pixee-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: pixee-shared
 description: "Describe the global flags, output format, exit codes, error handling, and TLS trust troubleshooting used by every Pixee CLI subcommand."
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   openclaw:
     category: "developer-tools"
     requires:
@@ -55,6 +55,9 @@ server-precedence rules, and `pixee auth status` — see `pixee-auth`.
 ## Global flags
 
 - `--server <url>` — override the configured server for a single invocation.
+- `--token <token>` — API token for this invocation; overrides `PIXEE_TOKEN` and the stored
+  config. See `pixee-auth` for the full credential-resolution order and the `--token -` stdin
+  pattern.
 - `--output text|json` — choose the output format. Default is `text` (flat, line-oriented output
   suitable for `grep`/`awk`). Use `json` for machine-readable output and pipe to `jq` for
   filtering; `pixee` does not embed a jq implementation.

--- a/skills/pixee-workflow/SKILL.md
+++ b/skills/pixee-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: pixee-workflow
 description: "List, create, update, run, and delete Pixee workflows on a repository with partial-update semantics across event kinds."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   openclaw:
     category: "developer-tools"
     requires:
@@ -17,8 +17,8 @@ metadata:
 > handling, `../pixee-auth/SKILL.md` if authentication needs to be configured, and
 > `../pixee-repo/SKILL.md` for the `--repo` resolution protocol.
 
-`pixee workflow` manages Pixee workflows for a single repository: list, create, update, run, and
-delete.
+`pixee workflow` manages Pixee workflows for a single repository: list, view, create, update, run,
+and delete.
 
 ## pixee workflow list
 
@@ -30,6 +30,24 @@ pixee workflow list --repo <name-or-uuid>
 - Text output is tab-separated with columns `id`, `event`, `action`, `tool`.
 - Pagination is transparent — every workflow on the repo is emitted in one call. There is no
   `--paginate` flag here; `--paginate` only lives on `pixee api`.
+
+## pixee workflow view
+
+```
+pixee workflow view <workflow-id>
+```
+
+Fetch a single workflow by UUID. `<workflow-id>` is the value shown in the `id` column of
+`pixee workflow list`.
+
+Default text mode prints a sectioned `Key: value` block of the workflow's headline fields — the
+same ones `list` surfaces (`id`, `name`, `event`, `action`, `tool`) plus the event-specific
+configuration (`cadence`/`branch`/`start` for `schedule`, `branch` for `new-scan`,
+`target-branch`/`source-branch` for `pull-request-scan`) — colon-separated, one field per line.
+Use `--output json` (or `--json`) for the full HAL body, which adds the `_links` envelope and any
+fields the text view omits. No flags beyond the global ones.
+
+A non-existent UUID returns the standard not-found error and exits 3.
 
 ## pixee workflow create
 
@@ -142,6 +160,12 @@ pixee workflow delete <workflow-id>
 ```bash
 # List every workflow on a repo
 pixee workflow list --repo pixee/pixee-platform
+
+# Inspect a single workflow by UUID
+pixee workflow view a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+
+# Pull the full HAL body to see the event-specific configuration
+pixee workflow view a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d --json | jq '{event, action, tool}'
 
 # Daily scheduled scan, patching high/critical Sonar findings on the default branch
 pixee workflow create schedule \

--- a/skills/pixee-workflow/SKILL.md
+++ b/skills/pixee-workflow/SKILL.md
@@ -27,7 +27,7 @@ pixee workflow list --repo <name-or-uuid>
 ```
 
 - `--repo` is **required**.
-- Text output is tab-separated with columns `id`, `event`, `action`, `tool`.
+- Text output is tab-separated with columns `id`, `name`, `event`, `action`, `tool`.
 - Pagination is transparent — every workflow on the repo is emitted in one call. There is no
   `--paginate` flag here; `--paginate` only lives on `pixee api`.
 


### PR DESCRIPTION
An audit-skills run against pixee 0.17.0 found the shipped skills had drifted from the binary: `pixee workflow view` and `pixee integration view` were entirely undocumented, and six `list` verbs carried missing or stale flag enums (`--scan`, `--search`/`--type`, `--results`, `--triage-suggested`, `--sca-classification`, `--sort`), plus a missing global `--token` flag in `pixee-shared`. Fixed everything in one PR rather than one-gap-per-run, since the changes are small and independently reviewable inline.
