### PR TITLE
📝 Add VS Code Agent Plugin Manifest And Complete Skill Frontmatter

### DIFF
--- a/.claude/skills/add-resource-skill/SKILL.md
+++ b/.claude/skills/add-resource-skill/SKILL.md
@@ -39,6 +39,8 @@ Copy this exactly and fill in the angle-bracket placeholders:
 ---
 name: pixee-<noun>
 description: "<verb-first, 100-130 chars, no colons, em-dashes, or parens>"
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.0.0
   openclaw:
@@ -57,6 +59,8 @@ The `description` has a triple constraint, each one load-bearing:
 - **(c) No colons, em-dashes, or parentheses.** They break the skills.sh picker silently. Commit `f0e73a3` (ISS-6922) rewrote all five existing descriptions for exactly this reason. Length: 100–130 chars.
 
 `version` stays `1.0.0` until we agree to start bumping. Don't invent a scheme.
+
+`license` is always `Apache-2.0` — it matches `skills/LICENSE`, which covers the whole directory. `compatibility` is always `Requires the pixee CLI binary on PATH` unless the skill has a genuinely different runtime dependency. Both fields complete the Agent Skills spec (agentskills.io/specification); every skill in this repo carries them (ISS-8576).
 
 `cliHelp` is `pixee <subcommand> --help` for command-backed skills; `pixee --help` for cross-cutting skills like `pixee-shared`.
 
@@ -87,6 +91,7 @@ Don't try to invent shape. Open the closest sibling and follow its skeleton. Eve
 2. **License.** The `skills/` directory is Apache-2.0 via `skills/LICENSE`. No per-file header. `skills/NOTICE` stays untouched unless the new skill pulls in third-party attributions (unlikely for documentation).
 3. **Commit style.** Follow recent history: short imperative + issue tag, e.g. `Add pixee-scan skill (ISS-XXXX)`. Use a fresh issue number — ISS-6922 is closed.
 4. **Picker smoke test.** Run `npx skills add pixee/pixee-cli` (no `--all`) and confirm the new entry appears in the interactive picker with its full description visible. If it's missing, the `description` has picker-breaking characters — fix before landing.
+5. **`plugin.json`.** The repo root `plugin.json` (VS Code Agent Plugins / Copilot CLI marketplace manifest) auto-discovers skills from `skills/*/SKILL.md` — adding or removing a skill doesn't require touching it. It versions independently of any skill's `metadata.version`, starting at `1.0.0`. Bump it (semver) only when `plugin.json`'s own fields change — name, description, keywords, license, author, repository — not on every skill edit.
 
 ## Updating an existing skill
 
@@ -94,6 +99,7 @@ Same rules, applied on the edit:
 
 - Preserve the description's verb-first, picker-friendly shape on any rewrite. A rewrite that introduces a colon or em-dash is a picker regression, not a prose polish.
 - Keep `version` decisions consistent across siblings. Don't bump one skill's version in isolation — the set moves together or stays.
+- `license` and `compatibility` are constants (see Frontmatter template above) — an edit should never change them unless the skill's actual binary dependency changes.
 - Don't diverge PREREQUISITE phrasing from the rest of the set in a single-skill edit. If the convention needs to change, update all five siblings in one commit.
 
 ## Anti-patterns

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "pixee-cli",
+  "version": "1.0.0",
+  "description": "Skills for using the Pixee CLI: authentication, scans, workflows, repositories, findings, and API access.",
+  "author": { "name": "Pixee, Inc.", "url": "https://pixee.ai" },
+  "homepage": "https://github.com/pixee/pixee-cli",
+  "repository": "https://github.com/pixee/pixee-cli",
+  "license": "Apache-2.0",
+  "keywords": ["pixee", "cli", "security", "appsec", "sast", "code-scanning", "vulnerability-management"]
+}

--- a/skills/pixee-analysis/SKILL.md
+++ b/skills/pixee-analysis/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-analysis
 description: "List, view, and delete Pixee analyses with filters and optional polling until the analysis reaches a terminal state."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.1.0
   openclaw:

--- a/skills/pixee-api/SKILL.md
+++ b/skills/pixee-api/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-api
 description: "Send authenticated requests to any Pixee REST API endpoint."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.0.0
   openclaw:

--- a/skills/pixee-auth/SKILL.md
+++ b/skills/pixee-auth/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-auth
 description: "Authenticate to a Pixee deployment using the per-user OAuth2 device flow or the deployment's shared API key, choose which deployment commands target, mint bearer tokens for the REST API and observability endpoints, and inspect the current authentication state."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.1.0
   openclaw:

--- a/skills/pixee-finding/SKILL.md
+++ b/skills/pixee-finding/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-finding
 description: "List, filter, and view Pixee findings for a scan with aggregate counts across triage, fix, and SCA outcomes."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.1.0
   openclaw:

--- a/skills/pixee-integration/SKILL.md
+++ b/skills/pixee-integration/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-integration
 description: "List Pixee integrations to discover the id, type, and capabilities of each scanner integration registered with the org."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.1.0
   openclaw:

--- a/skills/pixee-preferences/SKILL.md
+++ b/skills/pixee-preferences/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-preferences
 description: "Read and write Pixee organization preferences from files or stdin with optimistic concurrency handled by the CLI."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.0.0
   openclaw:

--- a/skills/pixee-repo/SKILL.md
+++ b/skills/pixee-repo/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-repo
 description: "List, view, and delete Pixee repositories with shared name-or-UUID resolution used by every targeted subcommand."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.0.0
   openclaw:

--- a/skills/pixee-scan/SKILL.md
+++ b/skills/pixee-scan/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-scan
 description: "List, view, analyze, create, and delete Pixee scans with filters for repository, branch, detector tool, and analysis state."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.0.0
   openclaw:

--- a/skills/pixee-shared/SKILL.md
+++ b/skills/pixee-shared/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-shared
 description: "Describe the global flags, output format, exit codes, error handling, and TLS trust troubleshooting used by every Pixee CLI subcommand."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.2.0
   openclaw:

--- a/skills/pixee-workflow/SKILL.md
+++ b/skills/pixee-workflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pixee-workflow
 description: "List, create, update, run, and delete Pixee workflows on a repository with partial-update semantics across event kinds."
+license: Apache-2.0
+compatibility: Requires the pixee CLI binary on PATH
 metadata:
   version: 1.1.0
   openclaw:


### PR DESCRIPTION
Adds a plugin.json at the repo root so the pixee-cli skills are discoverable through VS Code's @agentPlugins marketplace search and the Copilot CLI's plugin install flows, since these only index repos that declare a plugin.json. Skills are auto-discovered from skills/*/SKILL.md, so no per-skill entries are needed. The plugin versions independently starting at 1.0.0, and its license (Apache-2.0) matches skills/LICENSE, describing the plugin's actual content in skills/.

Also completes each of the 10 pixee-* SKILL.md frontmatter blocks to the full Agent Skills spec by adding license and compatibility fields, which were previously absent.

/close ISS-8576