### PR TITLE
📝 Document Plugin Install For All Supported Coding Agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "pixee-cli",
+  "name": "pixee",
   "owner": { "name": "Pixee, Inc." },
   "metadata": {
-    "description": "Skills for using the Pixee CLI: authentication, scans, workflows, repositories, findings, and API access.",
+    "description": "Pixee coding-agent plugins.",
     "version": "1.0.0"
   },
   "plugins": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "pixee-cli",
+  "owner": { "name": "Pixee, Inc." },
+  "metadata": {
+    "description": "Skills for using the Pixee CLI: authentication, scans, workflows, repositories, findings, and API access.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "pixee-cli",
+      "source": "./",
+      "description": "Skills for using the Pixee CLI: authentication, scans, workflows, repositories, findings, and API access."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "pixee-cli",
+  "version": "1.0.0",
+  "description": "Skills for using the Pixee CLI: authentication, scans, workflows, repositories, findings, and API access.",
+  "author": { "name": "Pixee, Inc.", "url": "https://pixee.ai" },
+  "homepage": "https://github.com/pixee/pixee-cli",
+  "repository": "https://github.com/pixee/pixee-cli",
+  "license": "Apache-2.0",
+  "keywords": ["pixee", "cli", "security", "appsec", "sast", "code-scanning", "vulnerability-management"]
+}

--- a/.claude/skills/add-resource-skill/SKILL.md
+++ b/.claude/skills/add-resource-skill/SKILL.md
@@ -84,14 +84,18 @@ Don't try to invent shape. Open the closest sibling and follow its skeleton. Eve
 
 ## After you author
 
-1. **Update `README.md`.** Add a bullet under `## Coding agent skills` matching the shape of the existing five bullets:
+1. **Update `README.md`.** Add a bullet under `## Coding agent plugin` (in the `npx skills` fallback subsection) matching the shape of the existing bullets:
    ```markdown
    - [`pixee-<noun>`](./skills/pixee-<noun>/SKILL.md) — <one-line description matching the frontmatter>.
    ```
 2. **License.** The `skills/` directory is Apache-2.0 via `skills/LICENSE`. No per-file header. `skills/NOTICE` stays untouched unless the new skill pulls in third-party attributions (unlikely for documentation).
 3. **Commit style.** Follow recent history: short imperative + issue tag, e.g. `Add pixee-scan skill (ISS-XXXX)`. Use a fresh issue number — ISS-6922 is closed.
 4. **Picker smoke test.** Run `npx skills add pixee/pixee-cli` (no `--all`) and confirm the new entry appears in the interactive picker with its full description visible. If it's missing, the `description` has picker-breaking characters — fix before landing.
-5. **`plugin.json`.** The repo root `plugin.json` (VS Code Agent Plugins / Copilot CLI marketplace manifest) auto-discovers skills from `skills/*/SKILL.md` — adding or removing a skill doesn't require touching it. It versions independently of any skill's `metadata.version`, starting at `1.0.0`. Bump it (semver) only when `plugin.json`'s own fields change — name, description, keywords, license, author, repository — not on every skill edit.
+5. **Plugin manifests.** Two manifests both auto-discover skills from `skills/*/SKILL.md` — adding or removing a skill doesn't require touching either:
+   - Root [`plugin.json`](../../../plugin.json) — the Agent Plugins spec, read by VS Code, Copilot CLI, and Cursor.
+   - [`.claude-plugin/plugin.json`](../../../.claude-plugin/plugin.json) and [`.claude-plugin/marketplace.json`](../../../.claude-plugin/marketplace.json) — Claude Code's format, also read by Codex CLI.
+
+   Both version independently of any skill's `metadata.version`, starting at `1.0.0`, and move together — they describe the same plugin. Bump them (semver, all three files in lockstep) only when the plugin's own identity changes — name, description, keywords, license, author, repository — not on every skill edit.
 
 ## Updating an existing skill
 

--- a/.claude/skills/add-resource-skill/SKILL.md
+++ b/.claude/skills/add-resource-skill/SKILL.md
@@ -92,10 +92,12 @@ Don't try to invent shape. Open the closest sibling and follow its skeleton. Eve
 3. **Commit style.** Follow recent history: short imperative + issue tag, e.g. `Add pixee-scan skill (ISS-XXXX)`. Use a fresh issue number — ISS-6922 is closed.
 4. **Picker smoke test.** Run `npx skills add pixee/pixee-cli` (no `--all`) and confirm the new entry appears in the interactive picker with its full description visible. If it's missing, the `description` has picker-breaking characters — fix before landing.
 5. **Plugin manifests.** Two manifests both auto-discover skills from `skills/*/SKILL.md` — adding or removing a skill doesn't require touching either:
-   - Root [`plugin.json`](../../../plugin.json) — the Agent Plugins spec, read by VS Code, Copilot CLI, and Cursor.
-   - [`.claude-plugin/plugin.json`](../../../.claude-plugin/plugin.json) and [`.claude-plugin/marketplace.json`](../../../.claude-plugin/marketplace.json) — Claude Code's format, also read by Codex CLI.
+   - Root [`plugin.json`](../../../plugin.json) — the Agent Plugins spec, read by VS Code and Cursor.
+   - [`.claude-plugin/plugin.json`](../../../.claude-plugin/plugin.json) and [`.claude-plugin/marketplace.json`](../../../.claude-plugin/marketplace.json) — Claude Code's format, also read by GitHub Copilot CLI and Codex CLI.
 
    Both version independently of any skill's `metadata.version`, starting at `1.0.0`, and move together — they describe the same plugin. Bump them (semver, all three files in lockstep) only when the plugin's own identity changes — name, description, keywords, license, author, repository — not on every skill edit.
+
+   `marketplace.json`'s top-level `name` is `pixee` (the org), deliberately not `pixee-cli` (the repo/plugin) — this lets future Pixee plugins join the same marketplace without a rename. Never change it to match the repo name; that's not a bug to fix.
 
 ## Updating an existing skill
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ security backlog instead of growing it. Learn more at [pixee.ai](https://pixee.a
 
 This repository distributes `pixee`, the official command-line interface for the Pixee platform. It
 is intended for Pixee customers and gives authenticated access to the Pixee REST API through dedicated
-subcommands and a generic `pixee api` passthrough, and ships with coding-agent skills so tools like
-Claude Code and OpenAI Codex can drive it natively.
+subcommands and a generic `pixee api` passthrough, and ships as an installable coding-agent plugin so
+tools like GitHub Copilot, VS Code, Claude Code, and OpenAI Codex can drive it natively.
 
 ## Install
 
@@ -112,11 +112,36 @@ order (bundled Mozilla CAs → system keychain when `NODE_USE_SYSTEM_CA=1` → `
 [Node's `NODE_EXTRA_CA_CERTS` docs](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) for the env-var contract
 Bun inherits.
 
-## Coding agent skills
+## Coding agent plugin
 
-The Pixee CLI ships with [skills.sh](https://skills.sh)-formatted skills that teach coding agents
-(Claude Code, OpenAI Codex, and others) how to drive the CLI. The skills live under
-[`skills/`](./skills/) and are licensed separately under the Apache License, Version 2.0.
+The Pixee CLI ships as an installable [Agent Plugin](https://agent-plugins.org) ([`plugin.json`](./plugin.json))
+bundling skills that teach coding agents (GitHub Copilot, Claude Code, OpenAI Codex, and others) how to
+drive the CLI. The skills live under [`skills/`](./skills/) and are licensed separately under the Apache
+License, Version 2.0.
+
+### GitHub Copilot CLI
+
+```bash
+copilot plugin install pixee/pixee-cli
+```
+
+### VS Code (GitHub Copilot Chat)
+
+Register this repo as a plugin marketplace in your `settings.json`:
+
+```jsonc
+"chat.plugins.enabled": true,
+"chat.plugins.marketplaces": ["pixee/pixee-cli"]
+```
+
+Then search `@agentPlugins` in the Extensions view and install `pixee-cli`.
+
+### `npx skills` (fallback)
+
+Tools that don't yet support the Agent Plugins spec can install the underlying
+[skills.sh](https://skills.sh)-formatted skills directly. This method only installs `SKILL.md` files — it
+skips whatever else the plugin bundles (agents, hooks, MCP servers) and won't stay in sync with the
+plugin's marketplace listing, so prefer the plugin install methods above when your agent supports them.
 
 Install every skill at once:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ security backlog instead of growing it. Learn more at [pixee.ai](https://pixee.a
 This repository distributes `pixee`, the official command-line interface for the Pixee platform. It
 is intended for Pixee customers and gives authenticated access to the Pixee REST API through dedicated
 subcommands and a generic `pixee api` passthrough, and ships as an installable coding-agent plugin so
-tools like GitHub Copilot, VS Code, Claude Code, and OpenAI Codex can drive it natively.
+tools like GitHub Copilot, VS Code, Cursor, Claude Code, and OpenAI Codex can drive it natively.
 
 ## Install
 
@@ -114,10 +114,15 @@ Bun inherits.
 
 ## Coding agent plugin
 
-The Pixee CLI ships as an installable [Agent Plugin](https://agent-plugins.org) ([`plugin.json`](./plugin.json))
-bundling skills that teach coding agents (GitHub Copilot, Claude Code, OpenAI Codex, and others) how to
-drive the CLI. The skills live under [`skills/`](./skills/) and are licensed separately under the Apache
-License, Version 2.0.
+The Pixee CLI ships as an installable plugin bundling the skills under [`skills/`](./skills/), which
+teach coding agents how to drive the CLI and are licensed separately under the Apache License, Version
+2.0. Two manifests describe the same plugin, since the ecosystem hasn't converged on one format yet:
+
+- [`plugin.json`](./plugin.json) at the repo root — the [Agent Plugins](https://agent-plugins.org)
+  standard, read by VS Code, GitHub Copilot CLI, and Cursor.
+- [`.claude-plugin/`](./.claude-plugin/) — Claude Code's plugin format, also read by OpenAI Codex CLI.
+
+Pick the section for your agent below. All of them install the same 10 skills.
 
 ### GitHub Copilot CLI
 
@@ -136,12 +141,33 @@ Register this repo as a plugin marketplace in your `settings.json`:
 
 Then search `@agentPlugins` in the Extensions view and install `pixee-cli`.
 
+### Cursor
+
+From the Cursor dashboard: **Plugins → Team Marketplaces → Add Marketplace → Import from Repo**, pointing
+at `pixee/pixee-cli`. Cursor loads Agent Plugins-spec plugins without changes.
+
+### Claude Code
+
+```bash
+claude plugin marketplace add pixee/pixee-cli
+claude plugin install pixee-cli@pixee-cli
+```
+
+### OpenAI Codex CLI
+
+```bash
+codex plugin marketplace add pixee/pixee-cli
+codex plugin add pixee-cli@pixee-cli
+```
+
+Requires Codex CLI 0.147.0 or later — earlier versions don't support portable Agent Plugin installs.
+
 ### `npx skills` (fallback)
 
-Tools that don't yet support the Agent Plugins spec can install the underlying
+Tools that don't yet support either plugin format can install the underlying
 [skills.sh](https://skills.sh)-formatted skills directly. This method only installs `SKILL.md` files — it
-skips whatever else the plugin bundles (agents, hooks, MCP servers) and won't stay in sync with the
-plugin's marketplace listing, so prefer the plugin install methods above when your agent supports them.
+skips whatever else a plugin bundles (agents, hooks, MCP servers) and won't stay in sync with the
+marketplace listings above, so prefer a plugin install method when your agent supports one.
 
 Install every skill at once:
 

--- a/README.md
+++ b/README.md
@@ -119,15 +119,18 @@ teach coding agents how to drive the CLI and are licensed separately under the A
 2.0. Two manifests describe the same plugin, since the ecosystem hasn't converged on one format yet:
 
 - [`plugin.json`](./plugin.json) at the repo root — the [Agent Plugins](https://agent-plugins.org)
-  standard, read by VS Code, GitHub Copilot CLI, and Cursor.
-- [`.claude-plugin/`](./.claude-plugin/) — Claude Code's plugin format, also read by OpenAI Codex CLI.
+  standard, read by VS Code and Cursor.
+- [`.claude-plugin/`](./.claude-plugin/) — Claude Code's plugin format, also read by GitHub Copilot CLI
+  and OpenAI Codex CLI. Its marketplace is named `pixee`, not `pixee-cli`, so future Pixee plugins can
+  join the same marketplace without a naming collision.
 
 Pick the section for your agent below. All of them install the same 10 skills.
 
 ### GitHub Copilot CLI
 
 ```bash
-copilot plugin install pixee/pixee-cli
+copilot plugin marketplace add pixee/pixee-cli
+copilot plugin install pixee-cli@pixee
 ```
 
 ### VS Code (GitHub Copilot Chat)
@@ -150,14 +153,14 @@ at `pixee/pixee-cli`. Cursor loads Agent Plugins-spec plugins without changes.
 
 ```bash
 claude plugin marketplace add pixee/pixee-cli
-claude plugin install pixee-cli@pixee-cli
+claude plugin install pixee-cli@pixee
 ```
 
 ### OpenAI Codex CLI
 
 ```bash
 codex plugin marketplace add pixee/pixee-cli
-codex plugin add pixee-cli@pixee-cli
+codex plugin add pixee-cli@pixee
 ```
 
 Requires Codex CLI 0.147.0 or later — earlier versions don't support portable Agent Plugin installs.


### PR DESCRIPTION
Renames the README's Coding agent skills header to Coding agent plugin and leads with plugin install instructions before the npx skills fallback, now that plugin.json is merged and verified working end to end.

Adds .claude-plugin/plugin.json and .claude-plugin/marketplace.json alongside the existing root plugin.json, since Claude Code and OpenAI Codex CLI read Claude's plugin manifest format rather than the Agent Plugins spec. Verified both locally: claude plugin marketplace add/install and codex plugin marketplace add/add (Codex CLI 0.147.0+) both resolve all 10 skills against a local checkout of this branch.

Documents install steps for GitHub Copilot CLI, VS Code, Cursor, Claude Code, and OpenAI Codex CLI, and updates the add-resource-skill authoring guide so future skill additions know both manifest pairs auto-discover from skills/*/SKILL.md and version independently in lockstep.