### PR TITLE
📝 Document Content Negotiation And Stop Chasing Stale Scans

### DIFF
--- a/skills/pixee-api/SKILL.md
+++ b/skills/pixee-api/SKILL.md
@@ -71,6 +71,29 @@ This is pagination-strategy-agnostic: the CLI does not construct `page-number` q
 itself, so if the API migrates to a different strategy the same `--paginate` flag continues to
 work.
 
+## Non-JSON resources
+
+`pixee api` always sends `Accept: application/json` and has **no flag to override request
+headers** — there is no `-H`/`--header`. That is fine for the HAL API itself, but a handful of
+endpoints serve a specific representation of a resource in a non-JSON format (for example, a
+triage result's `report` and `article` links from `pixee-finding`, which render as markdown). Hit
+one of those through `pixee api` and it returns `406 Not Acceptable`, not JSON — that response is
+expected behavior for a mismatched Accept header, not a broken endpoint or a sign to keep probing
+with different flags.
+
+For those endpoints, drop to `curl` directly, using `pixee auth token` to mint the bearer token
+(same pattern `pixee-auth` documents for the `/o11y/` endpoints — the token is a bare string, so
+the `Authorization` header still needs an explicit `Bearer ` prefix):
+
+```bash
+TOKEN=$(pixee auth token --server https://pixee.example.com)
+curl -sS -H "Authorization: Bearer ${TOKEN}" -H "Accept: text/markdown" \
+  https://pixee.example.com/api/v1/triage-results/<id>/report
+```
+
+Reach for this only when a link's whole purpose is a non-JSON representation. If the resource is
+ordinary JSON, `pixee api` already sends the right `Accept` header and needs no help.
+
 ## Examples
 
 ```bash
@@ -96,3 +119,6 @@ pixee api /api/v1/repositories --paginate | jq '.[] | .full_name'
 - Prefer dedicated subcommands (`pixee repo list`, `pixee workflow list`) when they exist — they
   encode best practices on top of `pixee api`. Use `pixee api` as the escape hatch for operations
   that do not yet have a subcommand.
+- A `406 Not Acceptable` from `pixee api` means the resource only serves non-JSON content — see
+  **Non-JSON resources** above for the `curl` fallback. Don't retry with different `pixee api`
+  flags; there is no header override to reach for.

--- a/skills/pixee-finding/SKILL.md
+++ b/skills/pixee-finding/SKILL.md
@@ -97,6 +97,20 @@ the same flag.
   `suggested-severity`.
 - `--order <asc|desc>` — sort direction. Default `desc`.
 
+## Triage result links
+
+A `triage`-type representative-result carries its own `_links` beyond `self`/`finding`/`analysis`:
+`report` and `article` (both markdown-rendered explanations of the triage decision) and, for some
+outcome types, `verification`. `pixee api` requests JSON and gets `406 Not Acceptable` from these
+endpoints — see `pixee-api`'s **Non-JSON resources** section for the curl fallback that works.
+
+Before chasing `report`/`article`, check whether you already have what you need: the item's own
+`outcome.summary` — and on a blocked fix, `outcome.reason` / `outcome.details` — already inlines the
+triage/fix rationale in `pixee finding list` and `pixee finding view` output. `report`/`article` are
+worth a separate fetch mainly when you want the longer-form, formatted writeup instead of that
+summary. Not every link is populated for every outcome type — a 404 on `verification` means it does
+not apply to this result, not that something is broken.
+
 ## pixee finding view
 
 ```
@@ -161,3 +175,9 @@ pixee finding view AZ4JOwsipJDH8099SpHt --scan "$scan_id" --json \
   and on each result (`analysis`, `changesets`, `patches`, `latest-patch`) are the canonical way to
   reach related resources — follow them with `pixee api <href>` rather than guessing API paths.
   See `pixee-api` for HAL conventions and `--paginate`.
+- The **latest** scan for a branch is the current state of that branch, full stop. If it has zero
+  findings matching a filter (e.g. `--triage-suggested true_positive --stats` returns `"total": 0`),
+  that is the answer — "there are no true positives on the latest scan of `main`" — not a signal to
+  walk backward through older scans looking for a nonzero count. An older scan reflects a stale
+  commit and answering from one silently changes the question from "what's true today" to "what was
+  once true." Only look at a non-latest scan when the user asks about history explicitly.


### PR DESCRIPTION
pixee api has no header override flag, so hitting a triage-result's report or article link (markdown-only) returns 406 instead of the earlier confusion of a raw curl-with-hand-rolled-auth detour. Documents the sanctioned curl-with-bearer-token fallback, points out that outcome.summary/reason/details usually already answers the question inline, and adds a note that a latest scan with zero matching findings is itself the answer rather than a cue to walk backward through scan history.